### PR TITLE
Podman compatibility

### DIFF
--- a/lightstep-developer-satellite.sh
+++ b/lightstep-developer-satellite.sh
@@ -15,7 +15,7 @@ PSNAME=lightstep_developer_satellite
 
 STOP_CMD='  bash -c "$(curl -L https://raw.githubusercontent.com/lightstep/lightstep-developer-satellite/master/stop-developer-satellite.sh)"'
 
-docker > /dev/null 2>&1
+docker version > /dev/null 2>&1
 if [ $? -ne 0 ]; then
   echo "This version of the LightStep Satellite requires docker.  Please install docker before proceeding."
   exit 1


### PR DESCRIPTION
Use `docker version` instead of `docker` when checking if Docker is installed. When `docker` is used as an alias for `podman`, the original script fails, because `podman` without any subcommand exits with code `125`.

Many companies are moving towards `podman` as a drop-in replacement for `docker` for local development, because of licensing issues with Docker Desktop.